### PR TITLE
set min id length to 1

### DIFF
--- a/lib/amplitude_api.rb
+++ b/lib/amplitude_api.rb
@@ -72,7 +72,8 @@ class AmplitudeAPI
 
       JSON.generate(
         api_key: api_key,
-        events: event_body
+        events: event_body,
+        options: { min_id_length: 1 }
       )
     end
 

--- a/spec/lib/amplitude_api_spec.rb
+++ b/spec/lib/amplitude_api_spec.rb
@@ -17,7 +17,8 @@ describe AmplitudeAPI do
           )
           body = JSON.generate(
             api_key: described_class.api_key,
-            events: [event.to_hash]
+            events: [event.to_hash],
+            options: { min_id_length: 1 }
           )
 
           expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
@@ -34,7 +35,8 @@ describe AmplitudeAPI do
           )
           body = JSON.generate(
             api_key: described_class.api_key,
-            events: [event.to_hash]
+            events: [event.to_hash],
+            options: { min_id_length: 1 }
           )
 
           expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
@@ -52,7 +54,8 @@ describe AmplitudeAPI do
           )
           body = JSON.generate(
             api_key: described_class.api_key,
-            events: [event.to_hash]
+            events: [event.to_hash],
+            options: { min_id_length: 1 }
           )
 
           expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)
@@ -74,7 +77,8 @@ describe AmplitudeAPI do
         )
         body = JSON.generate(
           api_key: described_class.api_key,
-          events: [event.to_hash, event2.to_hash]
+          events: [event.to_hash, event2.to_hash],
+          options: { min_id_length: 1 }
         )
 
         expect(Typhoeus).to receive(:post).with(AmplitudeAPI::TRACK_URI_STRING, headers: headers, body: body)


### PR DESCRIPTION
Sets a min id length of 1. We have mostly uuids but some tracking ids remain as old legacy user ids, which can be of length <5. Amplitude by default errors in this case help.amplitude.com/hc/en-us/articles/360032842391-HTTP-API-V2#device-ids-and-user-ids-minimum-length